### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -11,10 +11,9 @@ dependencies = [
     "yarl",
 ]
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
-license = { text = "MIT License" }
+license = "MIT"
 
 [project.urls]
 Homepage = "https://github.com/autinerd/eheimdigital"


### PR DESCRIPTION
Hatchlin `1.27.0` added support for PEP 639 license expressions.
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files